### PR TITLE
Add new location to Hero create

### DIFF
--- a/app/controllers/api/heroes_controller.rb
+++ b/app/controllers/api/heroes_controller.rb
@@ -18,7 +18,7 @@ class Api::HeroesController < ApplicationController
     @hero = Hero.new(hero_params)
 
     if @hero.save
-      render json: @hero, status: :created, location: @hero
+      render json: @hero, status: :created, location: api_hero_url(@hero)
     else
       render json: @hero.errors, status: :unprocessable_entity
     end


### PR DESCRIPTION
## Contexto

Quando uma requisição `POST` é feita para o `/api/heroes` o server responde um `Internal Server Error` com a execeção:

`#<NoMethodError: undefined method 'hero_url' for #<Api::HeroesController:0x0000000000ade8>>`

## O que foi feito

Atualização do parâmetro `location` do método `create`
- Api::HeroesController